### PR TITLE
Add flask app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,234 @@
+import io
+import pickle
+
+from flask import Flask, render_template, Response
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle
+from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
+from matplotlib.figure import Figure
+
+import song_chooser
+from utils import listen_pattern, pitch_seq_to_cents, myround, pitch_to_cents
+
+app = Flask(__name__)
+
+# data = pickle.load(open("test.pkl", "rb"))
+data = song_chooser.SongChooser.get_data()
+
+@app.route('/')
+def home():
+    recordings = data.keys()
+    return render_template("index.html", recordings=recordings)
+
+@app.route('/recording/<string:title>')
+def recording(title):
+    if title not in data:
+        return "not found", 404
+    recording = data[title]
+
+    patterns = recording['parsed_patterns']
+    if recording['annotations'] is not None:
+        groups = recording['groups_with_annotations']
+    else:
+        groups = recording['groups']
+
+    return render_template("recording.html", title=title, patterns=patterns.keys(), groups=groups.keys())
+
+
+@app.route('/recording/<string:title>/<string:pat_type>/<string:identifier>')
+def pattern(title, pat_type, identifier):
+    ret, code = validate_args(title, pat_type, identifier)
+    if ret is not None:
+        return ret, code
+
+    recording = data[title]
+    if recording['annotations'] is not None:
+        groups = recording['groups_with_annotations']
+    else:
+        groups = recording['groups']
+    patterns = recording['parsed_patterns']
+
+    if pat_type == "Group":
+        # If the type is "Group" then the identifier is an int index. validate_args has already
+        # checked that it's a number and is within bounds
+        results = groups[int(identifier)]
+    elif pat_type == "Pattern":
+        # If type is "Pattern" then the identifier is a dict index into `patterns`. validate_args has
+        # checked that the index is valid
+        results = patterns[identifier]
+
+    return render_template("pattern.html", title=title, pat_type=pat_type, identifier=identifier, results=results)
+
+@app.route('/image/<string:title>/<string:pat_type>/<string:identifier>/<string:part>.png')
+def image(title, pat_type, identifier, part):
+
+    ret, code = validate_args(title, pat_type, identifier)
+    if ret is not None:
+        return ret, code
+
+    output = io.BytesIO()
+
+    recording = data[title]
+    annotations = recording['annotations']
+    freqs = recording['pitch_freqs']
+    times = recording['pitch_times']
+    pitch_hop = recording['pitch_hop']
+    plot_kwargs = recording['plot_kwargs']
+    patterns = recording['parsed_patterns']
+    if recording['annotations'] is not None:
+        groups = recording['groups_with_annotations']
+    else:
+        groups = recording['groups']
+
+    if pat_type == "Group":
+        # If the type is "Group" then the identifier is an int index. validate_args has already
+        # checked that it's a number and is within bounds
+        results = groups[int(identifier)]
+    elif pat_type == "Pattern":
+        # If type is "Pattern" then the identifier is a dict index into `patterns`. validate_args has
+        # checked that the index is valid
+        results = patterns[identifier]
+    
+    part = int(part)
+    if part >= len(results):
+        return "part too long", 400
+
+    fig = plot_patterns(recording, results[part], pat_type, freqs, times, pitch_hop, annotations, plot_kwargs)
+    FigureCanvas(fig).print_png(output)
+    return Response(output.getvalue(), mimetype='image/png')
+
+
+def validate_args(title, type, identifier):
+    if title not in data:
+        return "title not found", 404
+
+    if type not in ['Group', 'Pattern']:
+        return f"unknown type ({type})", 400
+
+    recording = data[title]
+    if recording['annotations'] is not None:
+        groups = recording['groups_with_annotations']
+    else:
+        groups = recording['groups']
+
+    if type == "Group":
+        try:
+            identifier = int(identifier)
+        except ValueError:
+            return "invalid group (not number)", 400
+        if identifier >= len(groups):
+            return "invalid group", 400
+
+    patterns = recording['parsed_patterns']
+
+    if type == "Pattern" and identifier not in patterns:
+        return "invalid pattern", 400
+
+    return None, None
+
+
+
+def plot_patterns(rec, pattern_info, option, freqs, times, pitch_hop, annotations, plot_kwargs):
+    sp = pattern_info[0]
+    l = pattern_info[1]
+    if annotations is not None:
+        pat = pattern_info[2]
+        pat_full = pattern_info[3]
+    else:
+        pat = None
+        pat_full = None
+    this_pitch = freqs[int(max(sp-l,0)):int(sp+2*l)]
+    this_times = times[int(max(sp-l,0)):int(sp+2*l)]
+    mask = np.full((len(this_pitch),), False)
+
+    tonic = plot_kwargs['tonic']
+    p1 = pitch_seq_to_cents(this_pitch, tonic)
+    figsize = plot_kwargs['figsize']
+    cents = plot_kwargs['cents']
+    s_len = len(this_pitch)
+    pitch_masked = np.ma.masked_where(mask, p1)
+    
+    plt.ion()
+    fig, ax = plt.subplots(figsize=figsize, nrows=1, ncols=1)
+    # hide toolbar and title
+    fig.canvas.toolbar_visible = False
+    fig.canvas.header_visible = False
+    fig.canvas.footer_visible = False
+    fig.patch.set_facecolor('white')
+
+    fig.subplots_adjust(wspace=0.3, hspace=0.20, top=0.85, bottom=0.1)
+    xlabel = 'Time (s)'
+    ylabel = f'Cents Above Tonic of {round(tonic)}Hz' if cents else 'Pitch (Hz)'
+
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)
+    plt.grid()
+
+    xmin = myround(min(this_times[:s_len]), 5)
+    xmax = max(this_times[:s_len])
+
+    sample = pitch_masked.data[:s_len]
+    if not set(sample) == {None}:
+        ymin_ = min([x for x in sample if x is not None])
+        ymin = myround(ymin_, 50)
+        ymax = max([x for x in sample if x is not None])
+    else:
+        ymin=0
+        ymax=1000
+    
+    for s in plot_kwargs['emphasize']:
+        assert plot_kwargs['yticks_dict'], \
+            "Empasize is for highlighting certain ticks in <yticks_dict>"
+        if s in plot_kwargs['yticks_dict']:
+            if cents:
+                p_ = pitch_to_cents(plot_kwargs['yticks_dict'][s], plot_kwargs['tonic'])
+            else:
+                p_ = plot_kwargs['yticks_dict'][s]
+            ax.axhline(p_, color='#db1f1f', linestyle='--', linewidth=1)
+
+    times_samp = this_times[:s_len]
+    pitch_masked_samp = pitch_masked[:s_len]
+
+    times_samp = times_samp[:min(len(times_samp), len(pitch_masked_samp))]
+    pitch_masked_samp = pitch_masked_samp[:min(len(times_samp), len(pitch_masked_samp))]
+    ax.plot(times_samp, pitch_masked_samp, linewidth=0.7)
+
+    if plot_kwargs['yticks_dict']:
+        tick_names = list(plot_kwargs['yticks_dict'].keys())
+        tick_loc = [pitch_to_cents(p, plot_kwargs['tonic']) if cents else p \
+                    for p in plot_kwargs['yticks_dict'].values()]
+        ax.set_yticks(tick_loc)
+        ax.set_yticklabels(tick_names)
+    
+    ax.set_xticks(np.arange(xmin, xmax+1, 1))
+
+    plt.xticks(fontsize=8.5)
+    ax.set_facecolor('#f2f2f2')
+
+    ax.set_ylim((ymin, ymax))
+    ax.set_xlim((xmin, xmax))
+        
+    x_d = ax.lines[-1].get_xdata()
+    y_d = ax.lines[-1].get_ydata()
+
+    x = x_d[int(min(l,sp)):int(l+min(l,sp))]
+    y = y_d[int(min(l,sp)):int(l+min(l,sp))]
+    
+    max_y = ax.get_ylim()[1]
+    min_y = ax.get_ylim()[0]
+    rect = Rectangle((x_d[int(min(l,sp))], min_y), l*pitch_hop, max_y-min_y, facecolor='lightgrey')
+    ax.add_patch(rect)
+    
+    ax.plot(x, y, linewidth=0.7, color='darkorange')
+    ax.axvline(x=x_d[int(min(l,sp))], linestyle="dashed", color='black', linewidth=0.8)
+
+    fig.canvas.draw()
+    fig.canvas.flush_events()
+    if 'Group' in option:
+        if annotations is not None:
+            print('This pattern has been identified to match:', pat[0])
+            print('The actual pattern in instance is:', pat_full[0])
+
+    return fig

--- a/app.py
+++ b/app.py
@@ -49,7 +49,14 @@ def recording(title):
     else:
         groups = recording['groups']
 
-    return render_template("recording.html", title=title, patterns=patterns.keys(), groups=groups.keys())
+    pattern_names =  None
+    if patterns:
+        pattern_names = [str(p) for p in patterns.keys()]
+    group_names = None
+    if groups:
+        group_names = [str(g) for g in groups.keys()]
+
+    return render_template("recording.html", title=title, patterns=pattern_names, groups=group_names)
 
 
 @app.route('/recording/<string:title>/<string:pat_type>/<string:identifier>')
@@ -66,8 +73,12 @@ def pattern(title, pat_type, identifier):
     else:
         groups = recording['groups']
     patterns = recording['parsed_patterns']
-    pattern_names = [str(p) for p in patterns.keys()]
-    group_names = [str(g) for g in groups.keys()]
+    pattern_names =  None
+    if patterns:
+        pattern_names = [str(p) for p in patterns.keys()]
+    group_names = None
+    if groups:
+        group_names = [str(g) for g in groups.keys()]
 
     if pat_type == "Group":
         # If the type is "Group" then the identifier is an int index. validate_args has already

--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ data = pickle.load(open("test.pkl", "rb"))
 #data = song_chooser.SongChooser.get_data()
 
 @app.route('/')
-def home():
+def index():
     recordings = list(data.keys())
     recordings.remove('audio')
     return render_template("index.html", recordings=recordings)
@@ -54,6 +54,8 @@ def pattern(title, pat_type, identifier):
     else:
         groups = recording['groups']
     patterns = recording['parsed_patterns']
+    pattern_names = [str(p) for p in patterns.keys()]
+    group_names = [str(g) for g in groups.keys()]
 
     if pat_type == "Group":
         # If the type is "Group" then the identifier is an int index. validate_args has already
@@ -65,8 +67,8 @@ def pattern(title, pat_type, identifier):
         results = patterns[identifier]
 
     return render_template(
-        "pattern.html", title=title, pat_type=pat_type, 
-        has_annotations=has_annotations, identifier=identifier, results=results
+        "recording.html", title=title, patterns=pattern_names, groups=group_names,
+        pat_type=pat_type, has_annotations=has_annotations, identifier=identifier, results=results
     )
 
 @app.route('/image/<string:title>/<string:pat_type>/<string:identifier>/<string:part>.png')

--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@ import io
 import os
 import pickle
 
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
 from flask import Flask, render_template, Response, send_from_directory
 from werkzeug.security import safe_join
 
@@ -14,10 +16,20 @@ from matplotlib.figure import Figure
 import song_chooser
 from utils import listen_pattern, pitch_seq_to_cents, myround, pitch_to_cents
 
-app = Flask(__name__)
+#data = pickle.load(open("test.pkl", "rb"))
+data = song_chooser.SongChooser.get_data()
 
-data = pickle.load(open("test.pkl", "rb"))
-#data = song_chooser.SongChooser.get_data()
+if "SENTRY_DSN" in os.environ:
+    sentry_sdk.init(
+        dsn=os.environ["SENTRY_DSN"],
+        integrations=[
+            FlaskIntegration(),
+        ],
+        traces_sample_rate=1.0
+    )
+
+
+app = Flask(__name__)
 
 @app.route('/')
 def index():

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,3 +83,5 @@ websocket-client==1.3.2
 websockets==10.3
 widgetsnbextension==3.5.0
 zipp==3.8.0
+uwsgi
+sentry-sdk[flask]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ defusedxml==0.7.1
 entrypoints==0.4
 executing==0.8.3
 fastjsonschema==2.15.3
+Flask==2.2.2
 idna==3.3
 importlib-metadata==4.11.4
 ipykernel==5.4.3

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,30 @@
+<!doctype html> 
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Sancara demo</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+
+  </head>
+  <body>
+
+    <div class="col-lg-8 mx-auto p-4 py-md-5">
+        <header class="d-flex align-items-center pb-3 mb-5 border-bottom">
+          <a href="/" class="d-flex align-items-center text-dark text-decoration-none">
+            <span class="fs-4">Sancara Demo</span>
+          </a>
+        </header>
+      
+        <main>
+          {% block content %}
+
+            {% endblock %}
+        </main>
+
+      </div>
+
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,7 +12,7 @@
     <div class="col-lg-8 mx-auto p-4 py-md-5">
         <header class="d-flex align-items-center pb-3 mb-5 border-bottom">
           <a href="/" class="d-flex align-items-center text-dark text-decoration-none">
-            <span class="fs-4">Sancara Demo</span>
+            <span class="fs-4">Searching for sañcāras</span>
           </a>
         </header>
       

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+Recordings:
+<ul>
+{% for recording in recordings %}
+  <li><a href="{{url_for('recording', title=recording)}}">{{recording}}</a></li>
+{% endfor %}
+
+<p>
+Groups: <a href="/">1</a> <a href="/">2</a> 3 <a href="/">4</a> <a href="/">4</a>
+</p>
+
+Patterns: <a href="/">aaaaabbab</a> <a href="/">bbbccaa</a> <a href="/">ccddccff</a>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,15 +1,21 @@
 {% extends "base.html" %}
 
 {% block content %}
-Recordings:
+
+<p>This online demo can be used to browse through the repeated melodic pattern groups in 
+Carnatic Music recordings. The patterns are grouped using a matrix similarity algorithm 
+on top of time and pitch invariant feature embeddings learnt by a complex auto-encoder 
+(CAE).</p>
+
+<p>You can browse the grouped patterns by performance. Some perfomances are annotated
+ by an expert. In such case, the user is able to browse the patters than have been 
+ assigned to such annotations, meaning these are musicologically-relevant for the
+ performance.</p>
+
+<h2>Recordings</h2>
 <ul>
 {% for recording in recordings %}
   <li><a href="{{url_for('recording', title=recording)}}">{{recording}}</a></li>
 {% endfor %}
 
-<p>
-Groups: <a href="/">1</a> <a href="/">2</a> 3 <a href="/">4</a> <a href="/">4</a>
-</p>
-
-Patterns: <a href="/">aaaaabbab</a> <a href="/">bbbccaa</a> <a href="/">ccddccff</a>
 {% endblock %}

--- a/templates/pattern.html
+++ b/templates/pattern.html
@@ -6,9 +6,19 @@ Pattern type: {{pat_type}}<br>
 Identifier: {{identifier}}
 
 {% for r in results %}
-<p>
-<img src="{{url_for('image', title=title, pat_type=pat_type, identifier=identifier, part=loop.index0)}}" />
-</p>
+<div class="d-flex align-items-center flex-column">
+    {% if pat_type == "Group" and has_annotations %}
+    <div>
+        This pattern has been identified to match: {{r[2][0]}}<br />
+        The actual pattern in instance is: {{r[3][0]}}
+    </div>
+    {% endif %}
+    <div>
+    <img style="width:100%; height:auto" src="{{url_for('image', title=title, pat_type=pat_type, identifier=identifier, part=loop.index0)}}" />
+</div><div>
+    <br><audio controls src="{{url_for('audio', rec=title, fold=r[-1], gr=r[-3], oc=r[-2])}}"> 
+    </div>
+</div>
 {% endfor %}
 
 {% endblock %}

--- a/templates/pattern.html
+++ b/templates/pattern.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+Recording {{title}}<br>
+Pattern type: {{pat_type}}<br>
+Identifier: {{identifier}}
+
+{% for r in results %}
+<p>
+<img src="{{url_for('image', title=title, pat_type=pat_type, identifier=identifier, part=loop.index0)}}" />
+</p>
+{% endfor %}
+
+{% endblock %}

--- a/templates/pattern.html
+++ b/templates/pattern.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 
 {% block content %}
-Recording {{title}}<br>
+<p><a href="{{url_for('index')}}">Return to recording list</a></p>
+<h3>Recording: {{title}}</h3>
+
 Pattern type: {{pat_type}}<br>
 Identifier: {{identifier}}
 
@@ -14,9 +16,10 @@ Identifier: {{identifier}}
     </div>
     {% endif %}
     <div>
-    <img style="width:100%; height:auto" src="{{url_for('image', title=title, pat_type=pat_type, identifier=identifier, part=loop.index0)}}" />
-</div><div>
-    <br><audio controls src="{{url_for('audio', rec=title, fold=r[-1], gr=r[-3], oc=r[-2])}}"> 
+        <img style="width:100%; height:auto" src="{{url_for('image', title=title, pat_type=pat_type, identifier=identifier, part=loop.index0)}}" />
+    </div>
+    <div>
+        <audio controls src="{{url_for('audio', rec=title, fold=r[-1], gr=r[-3], oc=r[-2])}}"> 
     </div>
 </div>
 {% endfor %}

--- a/templates/recording.html
+++ b/templates/recording.html
@@ -1,19 +1,20 @@
 {% extends "base.html" %}
 
 {% block content %}
-Recording {{title}}
+<h3>Recording: {{title}}</h3>
 
 <p>
 Groups: 
 {% for g in groups %}
-<a href="{{url_for('pattern', title=title, pat_type='Groups', identifier=g)}}">{{g}}</a>
+<a href="{{url_for('pattern', title=title, pat_type='Group', identifier=g)}}">{{g}}</a>
 {% endfor %}
 </p>
 
 <p>
 Patterns: 
 {% for p in patterns %}
-{{p}}
+<a href="{{url_for('pattern', title=title, pat_type='Pattern', identifier=p)}}">{{p}}</a>
 {% endfor %}
 </p>
+
 {% endblock %}

--- a/templates/recording.html
+++ b/templates/recording.html
@@ -1,20 +1,48 @@
 {% extends "base.html" %}
 
 {% block content %}
+<p><a href="{{url_for('index')}}">Return to recording list</a></p>
 <h3>Recording: {{title}}</h3>
 
 <p>
 Groups: 
 {% for g in groups %}
+{% if pat_type == 'Group' and identifier == g %}{{g}}{% else %}
 <a href="{{url_for('pattern', title=title, pat_type='Group', identifier=g)}}">{{g}}</a>
+{% endif %}
 {% endfor %}
 </p>
 
 <p>
 Patterns: 
 {% for p in patterns %}
+{% if pat_type == 'Pattern' and identifier == p %}{{p}}{% else %}
 <a href="{{url_for('pattern', title=title, pat_type='Pattern', identifier=p)}}">{{p}}</a>
+{% endif %}
 {% endfor %}
 </p>
+
+{% if results %}
+Pattern type: {{pat_type}}<br>
+Identifier: {{identifier}}
+
+{% for r in results %}
+<div class="d-flex align-items-center flex-column mb-7">
+    {% if pat_type == "Group" and has_annotations %}
+    <div>
+        This pattern has been identified to match: {{r[2][0]}}<br />
+        The actual pattern in instance is: {{r[3][0]}}
+    </div>
+    {% endif %}
+    <div>
+        <img style="width:100%; height:auto" src="{{url_for('image', title=title, pat_type=pat_type, identifier=identifier, part=loop.index0)}}" />
+    </div>
+    <div>
+        <audio controls src="{{url_for('audio', rec=title, fold=r[-1], gr=r[-3], oc=r[-2])}}"> 
+    </div>
+        <hr style="width: 100%">
+</div>
+{% endfor %}
+{% endif %}
 
 {% endblock %}

--- a/templates/recording.html
+++ b/templates/recording.html
@@ -4,6 +4,7 @@
 <p><a href="{{url_for('index')}}">Return to recording list</a></p>
 <h3>Recording: {{title}}</h3>
 
+{% if groups %}
 <p>
 Groups: 
 {% for g in groups %}
@@ -12,7 +13,9 @@ Groups:
 {% endif %}
 {% endfor %}
 </p>
+{% endif %}
 
+{% if patterns %}
 <p>
 Patterns: 
 {% for p in patterns %}
@@ -21,6 +24,7 @@ Patterns:
 {% endif %}
 {% endfor %}
 </p>
+{% endif %}
 
 {% if results %}
 Pattern type: {{pat_type}}<br>

--- a/templates/recording.html
+++ b/templates/recording.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block content %}
+Recording {{title}}
+
+<p>
+Groups: 
+{% for g in groups %}
+<a href="{{url_for('pattern', title=title, pat_type='Groups', identifier=g)}}">{{g}}</a>
+{% endfor %}
+</p>
+
+<p>
+Patterns: 
+{% for p in patterns %}
+{{p}}
+{% endfor %}
+</p>
+{% endblock %}

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,0 +1,9 @@
+[uwsgi]
+module = app
+callable = app
+enable-threads = true
+master = true
+http = 0.0.0.0:8888
+processes = 10
+log-x-forwarded-for = true
+chdir = /code


### PR DESCRIPTION
This adds a basic flask webapp to the demo so that it can be used without voila.

It has a very basic template, with some bootstrap to make it look a bit nicer.

install flask (pip install -r requirements.txt) and launch flask by running

    flask run

and then visit http://localhost:5000

On startup this will load the data. During development it's worth loading this from a pickle instead

```py
import pickle
import song_chooser
data = song_chooser.SongChooser.get_data()
with open("test.pkl", "wb") as fp:
    pickle.dump(data, fp)
```
and change the data loader in app.py to read this instead.

There are currently 3 pages, 
/ (index): Show a list of recordings
/recording/[recording name]: Show all the groups and patterns in this recording
/recording/[recording]/[Group|Pattern]/identifier: Show all of the images for a specific group or pattern

Images are rendered on the fly via the "/image" route. This passes in the recording name, "Group" or "Pattern", the identifier of the group or pattern, and an offset/part number to render. I copied the image render code from `create_vis`, ideally this code should be factored out into a method that can be used in all places. I'm not sure if it's worth generating the images once and saving them on disk.

~~There is still some work to be done to add some supporting text to the pages, and also information about the matching pattern in the case of a group. ("This pattern has been identified to match: pdsppddpmgrmgr. The actual pattern in instance is: pdsppddpmgrmgr")~~

~~Images are not resized on the page yet.~~
~~Audio players are not set up yet. In order to serve audio files we'll need to use [flask's `send_from_directory`](https://flask.palletsprojects.com/en/2.2.x/api/#flask.send_from_directory)~~

I'm still not sure if it makes sense to have a separate page for the list of recordings and a page for the groups and patterns in the recording which is separate from the page which shows the images. I think it would be nicer to be able to see the images but then be able to click to another pattern/group without using "back". perhaps "next/prev group/pattern" buttons would be useful for navigation too.

Happy to continue working on this on Monday!